### PR TITLE
An entry that sends back to offset 0 is certainly not valid. Ideally …

### DIFF
--- a/src/main/java/org/boris/pecoff4j/io/PEParser.java
+++ b/src/main/java/org/boris/pecoff4j/io/PEParser.java
@@ -754,7 +754,11 @@ public class PEParser {
       re.setId(id);
     }
     if ((offset & 0x80000000) != 0) {
-      dr.jumpTo(offset & 0x7fffffff);
+      int newOffset = offset & 0x7fffffff;
+      if (newOffset <= 0) {
+        throw new IllegalArgumentException("Invalid format, circular link detected.");
+      }
+      dr.jumpTo(newOffset);
       re.setDirectory(readResourceDirectory(dr, baseAddress));
     } else {
       dr.jumpTo(offset);


### PR DESCRIPTION
…we'd not have static methods in the parser, so that we could detect other types of circular dependencies, but at least we can fix the simple case.